### PR TITLE
Cap supported Python version at 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ A modular FastAPI backend that powers a South America-wide athletics portal. The
 - Federation ingestion pipeline stub backed by an in-process queue.
 - Comprehensive SOPs covering development, deployment, data ingestion, and operations.
 
+## Prerequisites
+- Python 3.11 or 3.12 (3.13 is not yet supported because of upstream dependency constraints.)
+- Git
+
 ## Getting Started
 1. **Install dependencies**
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pan-american-athletics-hub"
+version = "0.1.0"
+requires-python = ">=3.11,<3.13"
+description = "Backend for the Pan-American Athletics Hub"
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/sop/development.md
+++ b/sop/development.md
@@ -1,7 +1,7 @@
 # Development SOP
 
 ## 1. Prerequisites
-- Python 3.11+
+- Python 3.11 or 3.12 (we currently cap at <3.13 until dependencies add support)
 - Git
 - (Optional) SQLite CLI for inspecting the local database.
 


### PR DESCRIPTION
## Summary
- document that onboarding prerequisites require Python 3.11 or 3.12 because dependencies do not yet support 3.13
- add a minimal `pyproject.toml` that declares the `python_requires` range so packaging metadata enforces the cap

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0712250b88325947173abc4beb989