### PR TITLE
Document PYTHONPATH requirement for CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ A modular FastAPI backend that powers a South America-wide athletics portal. The
    pip install -r requirements.txt
    ```
 2. **Bootstrap the database**
+   > The project uses a `src/` layout, so either export `PYTHONPATH=src` once per shell session or prefix commands that import `app.*` modules.
    ```bash
-   python -c "import asyncio; from app.core.database import init_models; asyncio.run(init_models())"
+   PYTHONPATH=src python -c "import asyncio; from app.core.database import init_models; asyncio.run(init_models())"
    ```
 3. **Run the API**
    ```bash

--- a/sop/deployment.md
+++ b/sop/deployment.md
@@ -22,9 +22,9 @@ This SOP outlines how to deploy the FastAPI service onto a free-tier platform. I
 1. Create a free account at [Neon](https://console.neon.tech/).
 2. Provision a Postgres database and note the connection string.
 3. Update Railway environment variable `ATHLETICS_DATABASE_URL` with the Neon connection string (use `postgresql+psycopg_async://` driver, install `psycopg[binary]`).
-4. Run migrations/initialization:
+4. Run migrations/initialization (Railway shells need `PYTHONPATH=src` to resolve the `app.*` modules):
    ```bash
-   railway run "python -c 'import asyncio; from app.core.database import init_models; asyncio.run(init_models())'"
+   railway run "PYTHONPATH=src python -c 'import asyncio; from app.core.database import init_models; asyncio.run(init_models())'"
    ```
 
 ## 4. Continuous Deployment

--- a/sop/development.md
+++ b/sop/development.md
@@ -9,9 +9,9 @@
 1. Clone the repository and create a Python virtual environment.
 2. Install dependencies via `pip install -r requirements.txt`.
 3. Copy `.env.example` to `.env` (or create `.env`) if you need to override defaults.
-4. Initialize the database:
+4. Initialize the database (the repository uses a `src/` layout, so ensure `PYTHONPATH=src` is set):
    ```bash
-   python -c "import asyncio; from app.core.database import init_models; asyncio.run(init_models())"
+   PYTHONPATH=src python -c "import asyncio; from app.core.database import init_models; asyncio.run(init_models())"
    ```
 
 ## 3. Running Services Locally


### PR DESCRIPTION
## Summary
- document the src/ layout requirement in the README database bootstrap instructions
- update development and deployment SOPs to use PYTHONPATH=src when running one-off scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07149c8008325ba53bfdeaab1a5f4