### PR TITLE
Add development setup script and fix federation schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,14 @@ A modular FastAPI backend that powers a South America-wide athletics portal. The
 - Git
 
 ## Getting Started
-1. **Install dependencies**
+1. **Run the quick setup script** – automates virtualenv creation, dependency installation, `.env` generation, and database bootstrapping. Override defaults with `PYTHON_BIN`, `VENV_PATH`, or `REQUIREMENTS_FILE` as needed.
    ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   pip install -r requirements.txt
+   ./scripts/dev_setup.sh
    ```
-2. **Bootstrap the database**
-   > The project uses a `src/` layout, so either export `PYTHONPATH=src` once per shell session or prefix commands that import `app.*` modules.
+2. **Activate the virtual environment** (the script creates `.venv` by default)
    ```bash
-   PYTHONPATH=src python -c "import asyncio; from app.core.database import init_models; asyncio.run(init_models())"
+   source .venv/bin/activate
+   export PYTHONPATH=$(pwd)/src
    ```
 3. **Run the API**
    ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@
 
 ## Data Model Summary
 - `users`: core identities with roles (fan, athlete, coach, scout, federation, admin).
+- `federations`: directory of validated organizing bodies linked to events.
 - `events`: metadata describing meets, location, start/end dates, and associated federations.
 - `federation_submissions`: queue of ingestion payloads with status tracking.
 

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_PATH="${VENV_PATH:-$PROJECT_ROOT/.venv}"
+REQUIREMENTS_FILE="${REQUIREMENTS_FILE:-$PROJECT_ROOT/requirements.txt}"
+ENV_FILE="$PROJECT_ROOT/.env"
+ENV_EXAMPLE="$PROJECT_ROOT/.env.example"
+
+version_check="$($PYTHON_BIN -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')"
+if [[ "$version_check" != 3.11 && "$version_check" != 3.12 ]]; then
+  echo "[!] Python 3.11 or 3.12 is required. Current version: $version_check" >&2
+  exit 1
+fi
+
+echo "[+] Using Python interpreter: $PYTHON_BIN ($version_check)"
+
+echo "[+] Creating virtual environment at $VENV_PATH"
+"$PYTHON_BIN" -m venv "$VENV_PATH"
+source "$VENV_PATH/bin/activate"
+
+pip install --upgrade pip setuptools wheel
+pip install -r "$REQUIREMENTS_FILE"
+
+if [[ ! -f "$ENV_FILE" && -f "$ENV_EXAMPLE" ]]; then
+  echo "[+] Creating .env from .env.example"
+  cp "$ENV_EXAMPLE" "$ENV_FILE"
+fi
+
+export PYTHONPATH="$PROJECT_ROOT/src"
+
+echo "[+] Bootstrapping database"
+PYTHONPATH="$PYTHONPATH" python - <<'PYCODE'
+import asyncio
+from app.core.database import init_models
+
+asyncio.run(init_models())
+PYCODE
+
+echo "[✓] Development environment ready"
+
+echo "[i] Next steps:"
+echo "    source $VENV_PATH/bin/activate"
+echo "    export PYTHONPATH=$PROJECT_ROOT/src"
+echo "    uvicorn src.main:app --reload"

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,6 +1,6 @@
 from .base import Base
 from .event import Event
-from .federation import FederationSubmission
+from .federation import Federation, FederationSubmission
 from .user import User
 
-__all__ = ["Base", "Event", "FederationSubmission", "User"]
+__all__ = ["Base", "Event", "Federation", "FederationSubmission", "User"]

--- a/src/app/models/federation.py
+++ b/src/app/models/federation.py
@@ -4,6 +4,15 @@ from sqlalchemy.orm import Mapped, mapped_column
 from .base import Base
 
 
+class Federation(Base):
+    __tablename__ = "federations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False, unique=True)
+    country: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    website: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
 class FederationSubmission(Base):
     __tablename__ = "federation_submissions"
 


### PR DESCRIPTION
## Summary
- add a scripted development setup flow that provisions the virtualenv, installs dependencies, seeds configuration, and bootstraps the database
- document the quick-start workflow and extend the architecture data model with the federations table
- define a concrete `Federation` ORM model so event foreign keys resolve cleanly

## Testing
- python3 -m compileall src/app/models

------
https://chatgpt.com/codex/tasks/task_e_68e072cea99083259f7bb9729d476843