### PR TITLE
Add interactive frontend dashboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.110.0
 uvicorn[standard]==0.27.1
 sqlalchemy[asyncio]==2.0.27
 pydantic==2.6.4
+email-validator==2.1.1
 pydantic-settings==2.2.1
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.9

--- a/src/app/api/v1/routes/accounts.py
+++ b/src/app/api/v1/routes/accounts.py
@@ -17,6 +17,11 @@ async def register_user(
     return user
 
 
+@router.get("/", response_model=list[UserRead])
+async def list_users(service: AccountsService = Depends(get_accounts_service)) -> list[UserRead]:
+    return await service.list_users()
+
+
 @router.get("/{user_id}", response_model=UserRead)
 async def get_user(
     user_id: int, service: AccountsService = Depends(get_accounts_service)

--- a/src/app/services/accounts.py
+++ b/src/app/services/accounts.py
@@ -35,6 +35,11 @@ class AccountsService:
         await self._session.refresh(user)
         return UserRead.model_validate(user)
 
+    async def list_users(self) -> list[UserRead]:
+        result = await self._session.execute(select(User))
+        users = result.scalars().all()
+        return [UserRead.model_validate(user) for user in users]
+
 
 async def get_accounts_service(
     session: AsyncSession = Depends(get_session),

--- a/src/app/web/static/app.js
+++ b/src/app/web/static/app.js
@@ -1,0 +1,286 @@
+const API_BASE = "/api/v1";
+const notifications = document.querySelector("#notifications");
+const athleteList = document.querySelector("#athletes-list");
+const athleteEmpty = document.querySelector("#athletes-empty");
+const athleteForm = document.querySelector("#athlete-form");
+const seedAthletesButton = document.querySelector("#seed-athletes");
+const eventList = document.querySelector("#events-list");
+const eventEmpty = document.querySelector("#events-empty");
+const eventForm = document.querySelector("#event-form");
+const seedEventsButton = document.querySelector("#seed-events");
+
+document.querySelector("#api-base").textContent = API_BASE;
+
+const sampleAthletes = [
+  {
+    full_name: "Ramiro Lightfoot",
+    email: "ramiro.lightfoot@example.com",
+    role: "athlete",
+    password: "Shimmering123",
+  },
+  {
+    full_name: "Sofia Delgado",
+    email: "sofia.delgado@example.com",
+    role: "athlete",
+    password: "Sprinter123",
+  },
+  {
+    full_name: "Liam O'Connor",
+    email: "liam.oconnor@example.com",
+    role: "athlete",
+    password: "Hurdles123",
+  },
+];
+
+const sampleEvents = [
+  {
+    name: "Aurora Indoor Classic",
+    location: "Oslo, Norway",
+    start_date: "2024-02-10",
+    end_date: "2024-02-12",
+    federation_id: null,
+  },
+  {
+    name: "Sunset Coast Invitational",
+    location: "Porto, Portugal",
+    start_date: "2024-04-22",
+    end_date: "2024-04-24",
+    federation_id: null,
+  },
+  {
+    name: "Highlands Distance Festival",
+    location: "Edinburgh, Scotland",
+    start_date: "2024-09-14",
+    end_date: "2024-09-15",
+    federation_id: null,
+  },
+];
+
+const state = {
+  athletes: [],
+  events: [],
+};
+
+function notify(type, message) {
+  const toast = document.createElement("div");
+  toast.className = `toast ${type}`;
+  toast.textContent = message;
+  notifications.appendChild(toast);
+  setTimeout(() => {
+    toast.classList.add("fade");
+    toast.addEventListener(
+      "transitionend",
+      () => toast.remove(),
+      { once: true }
+    );
+    toast.style.opacity = "0";
+  }, 3500);
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    const error = new Error(detail?.detail || response.statusText || "Request failed");
+    error.status = response.status;
+    error.payload = detail;
+    throw error;
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function renderAthletes() {
+  athleteList.innerHTML = "";
+  if (!state.athletes.length) {
+    athleteEmpty.hidden = false;
+    return;
+  }
+  athleteEmpty.hidden = true;
+  state.athletes.forEach((athlete) => {
+    const item = document.createElement("li");
+    item.className = "card";
+    const created = new Date(athlete.created_at);
+    item.innerHTML = `
+      <div class="card-meta">
+        <span class="tag">${athlete.role}</span>
+        <span>${athlete.email}</span>
+        <span>${created.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}</span>
+      </div>
+      <h3>${athlete.full_name}</h3>
+    `;
+    athleteList.appendChild(item);
+  });
+}
+
+function renderEvents() {
+  eventList.innerHTML = "";
+  if (!state.events.length) {
+    eventEmpty.hidden = false;
+    return;
+  }
+  eventEmpty.hidden = true;
+  state.events.forEach((event) => {
+    const item = document.createElement("li");
+    item.className = "card";
+    const start = new Date(event.start_date);
+    const end = new Date(event.end_date);
+    item.innerHTML = `
+      <h3>${event.name}</h3>
+      <div class="card-meta">
+        <span class="tag">${event.location}</span>
+        <span>${start.toLocaleDateString()} - ${end.toLocaleDateString()}</span>
+        ${event.federation_id ? `<span>Federation #${event.federation_id}</span>` : ""}
+      </div>
+    `;
+    eventList.appendChild(item);
+  });
+}
+
+async function loadAthletes() {
+  try {
+    const data = await request("/accounts/");
+    state.athletes = data;
+    renderAthletes();
+  } catch (error) {
+    notify("error", `Unable to load athletes: ${error.message}`);
+    console.error(error);
+  }
+}
+
+async function loadEvents() {
+  try {
+    const data = await request("/events/");
+    state.events = data;
+    renderEvents();
+  } catch (error) {
+    notify("error", `Unable to load events: ${error.message}`);
+    console.error(error);
+  }
+}
+
+function serializeForm(form) {
+  const formData = new FormData(form);
+  return Object.fromEntries(formData.entries());
+}
+
+athleteForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const payload = serializeForm(athleteForm);
+  try {
+    await request("/accounts/register", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    athleteForm.reset();
+    notify("success", `Athlete \"${payload.full_name}\" registered successfully.`);
+    await loadAthletes();
+  } catch (error) {
+    if (error.status === 409) {
+      notify("error", "This email is already registered.");
+    } else {
+      notify("error", `Unable to register athlete: ${error.message}`);
+    }
+    console.error(error);
+  }
+});
+
+eventForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const payload = serializeForm(eventForm);
+  if (payload.federation_id === "") {
+    payload.federation_id = null;
+  } else {
+    payload.federation_id = Number(payload.federation_id);
+  }
+  try {
+    await request("/events/", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    eventForm.reset();
+    notify("success", `Event \"${payload.name}\" created successfully.`);
+    await loadEvents();
+  } catch (error) {
+    notify("error", `Unable to create event: ${error.message}`);
+    console.error(error);
+  }
+});
+
+async function seedAthletes() {
+  const existingEmails = new Set(state.athletes.map((athlete) => athlete.email));
+  for (const athlete of sampleAthletes) {
+    if (existingEmails.has(athlete.email)) {
+      continue;
+    }
+    try {
+      await request("/accounts/register", {
+        method: "POST",
+        body: JSON.stringify(athlete),
+      });
+    } catch (error) {
+      if (error.status !== 409) {
+        console.warn("Failed to seed athlete", athlete.email, error);
+      }
+    }
+  }
+  await loadAthletes();
+  notify("success", "Sample athletes are ready.");
+}
+
+async function seedEvents() {
+  const existingNames = new Set(state.events.map((event) => event.name));
+  for (const event of sampleEvents) {
+    if (existingNames.has(event.name)) {
+      continue;
+    }
+    try {
+      await request("/events/", {
+        method: "POST",
+        body: JSON.stringify(event),
+      });
+    } catch (error) {
+      if (error.status !== 400) {
+        console.warn("Failed to seed event", event.name, error);
+      }
+    }
+  }
+  await loadEvents();
+  notify("success", "Sample events are ready.");
+}
+
+seedAthletesButton.addEventListener("click", async () => {
+  seedAthletesButton.disabled = true;
+  await seedAthletes();
+  seedAthletesButton.disabled = false;
+});
+
+seedEventsButton.addEventListener("click", async () => {
+  seedEventsButton.disabled = true;
+  await seedEvents();
+  seedEventsButton.disabled = false;
+});
+
+async function initialize() {
+  await loadAthletes();
+  if (!state.athletes.length) {
+    await seedAthletes();
+  }
+  await loadEvents();
+  if (!state.events.length) {
+    await seedEvents();
+  }
+}
+
+initialize();

--- a/src/app/web/static/styles.css
+++ b/src/app/web/static/styles.css
@@ -1,0 +1,259 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --panel-bg: rgba(15, 23, 42, 0.85);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-image: radial-gradient(circle at top left, rgba(56, 189, 248, 0.4), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.25), transparent 45%);
+  background-color: var(--bg);
+  background-attachment: fixed;
+  margin: 0;
+  min-height: 100vh;
+}
+
+body {
+  margin: 0;
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+h1,
+ h2,
+ h3 {
+  margin: 0;
+  font-weight: 600;
+}
+
+p {
+  margin: 0;
+}
+
+.app-header {
+  padding: 3rem 5vw 2rem;
+  text-align: center;
+}
+
+.app-header h1 {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  letter-spacing: 0.05em;
+}
+
+.tagline {
+  color: var(--muted);
+  margin-top: 0.75rem;
+  font-size: 1.05rem;
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  padding: 0 5vw 4rem;
+}
+
+@media (min-width: 960px) {
+  .layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.panel {
+  background-color: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.panel-subtitle {
+  color: var(--muted);
+  margin-top: 0.5rem;
+  max-width: 32ch;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: #0f172a;
+  box-shadow: 0 12px 25px rgba(56, 189, 248, 0.35);
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid rgba(56, 189, 248, 0.45);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:active {
+  transform: translateY(0);
+}
+
+.form {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+input,
+ select {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  padding: 0.65rem 0.9rem;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+input:focus,
+ select:focus {
+  border-color: var(--accent);
+}
+
+.card-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.25rem;
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card h3 {
+  font-size: 1.1rem;
+}
+
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.tag {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.25rem 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.empty-state {
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  color: var(--muted);
+  background: rgba(15, 23, 42, 0.5);
+  text-align: center;
+}
+
+.hint {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.notifications {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  max-width: min(320px, 90vw);
+  z-index: 20;
+}
+
+.toast {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 0.85rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.45);
+  transition: opacity 0.35s ease;
+}
+
+.toast.success {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+
+.toast.error {
+  border-color: rgba(248, 113, 113, 0.55);
+}
+
+.app-footer {
+  margin-top: auto;
+  padding: 2rem 5vw 3rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+code {
+  background: rgba(15, 23, 42, 0.75);
+  padding: 0.25rem 0.45rem;
+  border-radius: 0.5rem;
+  font-size: 0.85rem;
+}

--- a/src/app/web/templates/index.html
+++ b/src/app/web/templates/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ramiro's Light - Athletics Hub</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Ramiro's Light</h1>
+      <p class="tagline">Discover athletes, explore events, and grow the athletics community.</p>
+    </header>
+
+    <main class="layout">
+      <section class="panel" aria-labelledby="athletes-title">
+        <div class="panel-header">
+          <div>
+            <h2 id="athletes-title">Athletes</h2>
+            <p class="panel-subtitle">Browse the current roster or register a new athlete profile.</p>
+          </div>
+          <button id="seed-athletes" class="secondary">Reload Sample Athletes</button>
+        </div>
+
+        <form id="athlete-form" class="form">
+          <h3>Create athlete</h3>
+          <div class="form-grid">
+            <label>
+              Full name
+              <input type="text" name="full_name" placeholder="Jane Runner" required />
+            </label>
+            <label>
+              Email
+              <input type="email" name="email" placeholder="jane@example.com" required />
+            </label>
+            <label>
+              Role
+              <input type="text" name="role" value="athlete" required />
+            </label>
+            <label>
+              Password
+              <input type="password" name="password" value="Password123" required />
+            </label>
+          </div>
+          <button type="submit" class="primary">Register athlete</button>
+        </form>
+
+        <div id="athletes-empty" class="empty-state" hidden>
+          <p>No athletes have been registered yet.</p>
+          <p class="hint">Use the form above or load the curated sample athletes to populate the roster.</p>
+        </div>
+
+        <ul id="athletes-list" class="card-list" aria-live="polite"></ul>
+      </section>
+
+      <section class="panel" aria-labelledby="events-title">
+        <div class="panel-header">
+          <div>
+            <h2 id="events-title">Events</h2>
+            <p class="panel-subtitle">Track the latest competitions and add new ones.</p>
+          </div>
+          <button id="seed-events" class="secondary">Reload Sample Events</button>
+        </div>
+
+        <form id="event-form" class="form">
+          <h3>Create event</h3>
+          <div class="form-grid">
+            <label>
+              Name
+              <input type="text" name="name" placeholder="Summer Invitational" required />
+            </label>
+            <label>
+              Location
+              <input type="text" name="location" placeholder="Lisbon, Portugal" required />
+            </label>
+            <label>
+              Start date
+              <input type="date" name="start_date" required />
+            </label>
+            <label>
+              End date
+              <input type="date" name="end_date" required />
+            </label>
+            <label>
+              Federation ID
+              <input type="number" name="federation_id" min="1" step="1" placeholder="Optional" />
+            </label>
+          </div>
+          <button type="submit" class="primary">Create event</button>
+        </form>
+
+        <div id="events-empty" class="empty-state" hidden>
+          <p>No events have been scheduled yet.</p>
+          <p class="hint">Use the form above or reload the curated calendar of sample events.</p>
+        </div>
+
+        <ul id="events-list" class="card-list" aria-live="polite"></ul>
+      </section>
+    </main>
+
+    <aside id="notifications" class="notifications" role="status" aria-live="assertive"></aside>
+
+    <footer class="app-footer">
+      <p>
+        Powered by FastAPI · API base: <code id="api-base">/api/v1</code>
+      </p>
+    </footer>
+
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,9 @@
-from fastapi import FastAPI
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
 from app.api.v1.routes import accounts, health, events, federations
 from app.core.config import SettingsSingleton
@@ -7,6 +12,16 @@ from app.core.config import SettingsSingleton
 def create_app() -> FastAPI:
     settings = SettingsSingleton().instance
     application = FastAPI(title=settings.project_name, version="1.0.0")
+
+    base_dir = Path(__file__).resolve().parent
+    templates = Jinja2Templates(directory=str(base_dir / "app" / "web" / "templates"))
+    static_dir = base_dir / "app" / "web" / "static"
+    if static_dir.exists():
+        application.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    @application.get("/", response_class=HTMLResponse)
+    async def render_index(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse("index.html", {"request": request})
 
     application.include_router(health.router, prefix=settings.api_v1_prefix)
     application.include_router(accounts.router, prefix=settings.api_v1_prefix)


### PR DESCRIPTION
## Summary
- add a FastAPI-served frontend with templates, styling, and interactive JavaScript dashboard
- expose a users listing endpoint and service helper to supply athlete data to the UI
- include seeded sample athletes and events plus required email validation dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e07d3f2eb08325b58bf368a934f06e