### PR TITLE
Add live event detail dashboards and demo tooling

### DIFF
--- a/src/app/api/v1/routes/events.py
+++ b/src/app/api/v1/routes/events.py
@@ -1,12 +1,24 @@
 from fastapi import APIRouter, Depends
 
-from app.schemas.event import EventCreate, EventRead
+from app.schemas.event import (
+    EventCreate,
+    EventDetailRead,
+    EventDisciplineCreate,
+    EventDisciplineRead,
+    EventEntryCreate,
+    EventEntryRead,
+    EventEntryUpdate,
+    EventFakeTimelineRequest,
+    EventRead,
+    EventSessionCreate,
+    EventSessionRead,
+)
 from app.services.events import EventsService, get_events_service
 
 router = APIRouter(prefix="/events", tags=["events"])
 
 
-@router.post("/", response_model=EventRead)
+@router.post("/", response_model=EventRead, status_code=201)
 async def create_event(
     payload: EventCreate, service: EventsService = Depends(get_events_service)
 ) -> EventRead:
@@ -16,3 +28,59 @@ async def create_event(
 @router.get("/", response_model=list[EventRead])
 async def list_events(service: EventsService = Depends(get_events_service)) -> list[EventRead]:
     return await service.list_events()
+
+
+@router.get("/{event_id}", response_model=EventDetailRead)
+async def read_event_detail(
+    event_id: int, service: EventsService = Depends(get_events_service)
+) -> EventDetailRead:
+    return await service.get_event_detail(event_id)
+
+
+@router.post("/{event_id}/sessions", response_model=EventSessionRead, status_code=201)
+async def create_event_session(
+    event_id: int,
+    payload: EventSessionCreate,
+    service: EventsService = Depends(get_events_service),
+) -> EventSessionRead:
+    return await service.create_session(event_id, payload)
+
+
+@router.post("/{event_id}/disciplines", response_model=EventDisciplineRead, status_code=201)
+async def create_event_discipline(
+    event_id: int,
+    payload: EventDisciplineCreate,
+    service: EventsService = Depends(get_events_service),
+) -> EventDisciplineRead:
+    return await service.create_discipline(event_id, payload)
+
+
+@router.post(
+    "/disciplines/{discipline_id}/entries",
+    response_model=EventEntryRead,
+    status_code=201,
+)
+async def create_event_entry(
+    discipline_id: int,
+    payload: EventEntryCreate,
+    service: EventsService = Depends(get_events_service),
+) -> EventEntryRead:
+    return await service.create_entry(discipline_id, payload)
+
+
+@router.patch("/entries/{entry_id}", response_model=EventEntryRead)
+async def update_event_entry(
+    entry_id: int,
+    payload: EventEntryUpdate,
+    service: EventsService = Depends(get_events_service),
+) -> EventEntryRead:
+    return await service.update_entry(entry_id, payload)
+
+
+@router.post("/{event_id}/demo", response_model=EventDetailRead)
+async def generate_event_demo(
+    event_id: int,
+    payload: EventFakeTimelineRequest,
+    service: EventsService = Depends(get_events_service),
+) -> EventDetailRead:
+    return await service.generate_fake_timeline(event_id, payload)

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,5 +1,13 @@
 from .base import Base
-from .event import Event
+from .event import (
+    Event,
+    EventDiscipline,
+    EventDisciplineStatus,
+    EventEntry,
+    EventEntryStatus,
+    EventSession,
+    EventSessionStatus,
+)
 from .federation import Federation, FederationSubmission, FederationSubmissionStatus
 from .news import NewsArticle, NewsAudience
 from .roster import Roster
@@ -9,6 +17,12 @@ __all__ = [
     "AthleteProfile",
     "Base",
     "Event",
+    "EventSession",
+    "EventDiscipline",
+    "EventEntry",
+    "EventSessionStatus",
+    "EventDisciplineStatus",
+    "EventEntryStatus",
     "Federation",
     "FederationSubmission",
     "FederationSubmissionStatus",

--- a/src/app/models/event.py
+++ b/src/app/models/event.py
@@ -1,7 +1,10 @@
-from datetime import date
+from __future__ import annotations
 
-from sqlalchemy import Date, ForeignKey, String
-from sqlalchemy.orm import Mapped, mapped_column
+from datetime import date, datetime
+from enum import Enum
+
+from sqlalchemy import Date, DateTime, Enum as SqlEnum, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .base import Base
 
@@ -15,3 +18,139 @@ class Event(Base):
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     end_date: Mapped[date] = mapped_column(Date, nullable=False)
     federation_id: Mapped[int | None] = mapped_column(ForeignKey("federations.id"), nullable=True)
+    sessions: Mapped[list["EventSession"]] = relationship(
+        "EventSession",
+        back_populates="event",
+        cascade="all, delete-orphan",
+        order_by="EventSession.start_time",
+    )
+    disciplines: Mapped[list["EventDiscipline"]] = relationship(
+        "EventDiscipline",
+        back_populates="event",
+        cascade="all, delete-orphan",
+        order_by="EventDiscipline.scheduled_start",
+    )
+
+
+class EventSessionStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    LIVE = "live"
+    COMPLETED = "completed"
+
+
+class EventDisciplineStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    LIVE = "live"
+    DELAYED = "delayed"
+    FINALIZED = "finalized"
+
+
+class EventEntryStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    READY = "ready"
+    LIVE = "live"
+    FINISHED = "finished"
+    DNS = "dns"
+    DQ = "dq"
+
+
+class EventSession(Base):
+    __tablename__ = "event_sessions"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    start_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    end_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    venue: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    status: Mapped[EventSessionStatus] = mapped_column(
+        SqlEnum(EventSessionStatus, name="event_session_status"),
+        default=EventSessionStatus.SCHEDULED,
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    event: Mapped[Event] = relationship("Event", back_populates="sessions")
+    disciplines: Mapped[list["EventDiscipline"]] = relationship(
+        "EventDiscipline",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="EventDiscipline.scheduled_start",
+    )
+
+
+class EventDiscipline(Base):
+    __tablename__ = "event_disciplines"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
+    session_id: Mapped[int | None] = mapped_column(
+        ForeignKey("event_sessions.id", ondelete="SET NULL"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    category: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    round_name: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    scheduled_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    scheduled_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[EventDisciplineStatus] = mapped_column(
+        SqlEnum(EventDisciplineStatus, name="event_discipline_status"),
+        default=EventDisciplineStatus.SCHEDULED,
+        nullable=False,
+    )
+    venue: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    order: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    event: Mapped[Event] = relationship("Event", back_populates="disciplines")
+    session: Mapped[EventSession | None] = relationship("EventSession", back_populates="disciplines")
+    entries: Mapped[list["EventEntry"]] = relationship(
+        "EventEntry",
+        back_populates="discipline",
+        cascade="all, delete-orphan",
+        order_by="EventEntry.lane",
+    )
+
+
+class EventEntry(Base):
+    __tablename__ = "event_entries"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    discipline_id: Mapped[int] = mapped_column(
+        ForeignKey("event_disciplines.id", ondelete="CASCADE"), nullable=False
+    )
+    roster_id: Mapped[int | None] = mapped_column(
+        ForeignKey("rosters.id", ondelete="SET NULL"), nullable=True
+    )
+    athlete_name: Mapped[str] = mapped_column(String(120), nullable=False)
+    team_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    bib: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    lane: Mapped[str | None] = mapped_column(String(12), nullable=True)
+    seed_mark: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    status: Mapped[EventEntryStatus] = mapped_column(
+        SqlEnum(EventEntryStatus, name="event_entry_status"),
+        default=EventEntryStatus.SCHEDULED,
+        nullable=False,
+    )
+    position: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    result: Mapped[str | None] = mapped_column(String(60), nullable=True)
+    points: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    discipline: Mapped[EventDiscipline] = relationship("EventDiscipline", back_populates="entries")
+    roster: Mapped["Roster | None"] = relationship("Roster", lazy="joined")
+
+
+__all__ = [
+    "Event",
+    "EventSession",
+    "EventDiscipline",
+    "EventEntry",
+    "EventSessionStatus",
+    "EventDisciplineStatus",
+    "EventEntryStatus",
+]

--- a/src/app/schemas/event.py
+++ b/src/app/schemas/event.py
@@ -1,4 +1,5 @@
-from datetime import date
+from datetime import date, datetime
+from enum import Enum
 
 from pydantic import BaseModel, Field
 
@@ -20,3 +21,133 @@ class EventRead(EventBase):
 
     class Config:
         from_attributes = True
+
+
+class EventSessionStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    LIVE = "live"
+    COMPLETED = "completed"
+
+
+class EventDisciplineStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    LIVE = "live"
+    DELAYED = "delayed"
+    FINALIZED = "finalized"
+
+
+class EventEntryStatus(str, Enum):
+    SCHEDULED = "scheduled"
+    READY = "ready"
+    LIVE = "live"
+    FINISHED = "finished"
+    DNS = "dns"
+    DQ = "dq"
+
+
+class EventSessionBase(BaseModel):
+    name: str = Field(..., min_length=3, max_length=120)
+    start_time: datetime | None = Field(default=None)
+    end_time: datetime | None = Field(default=None)
+    venue: str | None = Field(default=None, max_length=120)
+    description: str | None = Field(default=None, max_length=500)
+    status: EventSessionStatus = Field(default=EventSessionStatus.SCHEDULED)
+
+
+class EventSessionCreate(EventSessionBase):
+    pass
+
+
+class EventSessionRead(EventSessionBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class EventDisciplineBase(BaseModel):
+    name: str = Field(..., min_length=3, max_length=120)
+    category: str | None = Field(default=None, max_length=60)
+    round_name: str | None = Field(default=None, max_length=80)
+    scheduled_start: datetime | None = None
+    scheduled_end: datetime | None = None
+    status: EventDisciplineStatus = Field(default=EventDisciplineStatus.SCHEDULED)
+    venue: str | None = Field(default=None, max_length=120)
+    order: int | None = None
+
+
+class EventDisciplineCreate(EventDisciplineBase):
+    session_id: int | None = Field(default=None)
+
+
+class EventRosterStub(BaseModel):
+    id: int
+    name: str
+    country: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class EventEntryBase(BaseModel):
+    athlete_name: str = Field(..., min_length=1, max_length=120)
+    team_name: str | None = Field(default=None, max_length=120)
+    bib: str | None = Field(default=None, max_length=20)
+    lane: str | None = Field(default=None, max_length=12)
+    seed_mark: str | None = Field(default=None, max_length=40)
+    notes: str | None = Field(default=None, max_length=500)
+    status: EventEntryStatus = Field(default=EventEntryStatus.SCHEDULED)
+
+
+class EventEntryCreate(EventEntryBase):
+    roster_id: int | None = Field(default=None)
+
+
+class EventEntryUpdate(BaseModel):
+    athlete_name: str | None = Field(default=None, min_length=1, max_length=120)
+    team_name: str | None = Field(default=None, max_length=120)
+    bib: str | None = Field(default=None, max_length=20)
+    lane: str | None = Field(default=None, max_length=12)
+    seed_mark: str | None = Field(default=None, max_length=40)
+    notes: str | None = Field(default=None, max_length=500)
+    status: EventEntryStatus | None = None
+    position: int | None = Field(default=None, ge=1)
+    result: str | None = Field(default=None, max_length=60)
+    points: int | None = None
+
+
+class EventEntryRead(EventEntryBase):
+    id: int
+    position: int | None = None
+    result: str | None = None
+    points: int | None = None
+    roster_id: int | None = None
+    roster: EventRosterStub | None = None
+    updated_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class EventDisciplineRead(EventDisciplineBase):
+    id: int
+    session_id: int | None = None
+    session: EventSessionRead | None = None
+    entries: list[EventEntryRead] = Field(default_factory=list)
+
+    class Config:
+        from_attributes = True
+
+
+class EventDetailRead(EventRead):
+    sessions: list[EventSessionRead] = Field(default_factory=list)
+    disciplines: list[EventDisciplineRead] = Field(default_factory=list)
+    latest_update: datetime | None = None
+
+
+class EventFakeTimelineRequest(BaseModel):
+    start_time: datetime | None = Field(default=None, description="Anchor time for first session")
+    sessions: int = Field(default=2, ge=1, le=6)
+    disciplines_per_session: int = Field(default=3, ge=1, le=10)
+    lanes: int = Field(default=8, ge=2, le=12)
+    include_results: bool = Field(default=True)

--- a/src/app/services/events.py
+++ b/src/app/services/events.py
@@ -1,15 +1,65 @@
-from fastapi import Depends
-from sqlalchemy import select
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from random import sample
+
+from fastapi import Depends, HTTPException
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.core.database import get_session
-from app.models import Event
-from app.schemas.event import EventCreate, EventRead
+from app.models import (
+    Event,
+    EventDiscipline,
+    EventDisciplineStatus,
+    EventEntry,
+    EventEntryStatus,
+    EventSession,
+    EventSessionStatus,
+)
+from app.schemas.event import (
+    EventCreate,
+    EventDetailRead,
+    EventDisciplineCreate,
+    EventDisciplineRead,
+    EventEntryCreate,
+    EventEntryRead,
+    EventEntryUpdate,
+    EventFakeTimelineRequest,
+    EventRead,
+    EventSessionCreate,
+    EventSessionRead,
+)
 
 
 class EventsService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    async def _require_event(self, event_id: int) -> Event:
+        event = await self._session.get(Event, event_id)
+        if not event:
+            raise HTTPException(status_code=404, detail="Event not found")
+        return event
+
+    async def _require_session(self, session_id: int) -> EventSession:
+        session = await self._session.get(EventSession, session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Event session not found")
+        return session
+
+    async def _require_discipline(self, discipline_id: int) -> EventDiscipline:
+        discipline = await self._session.get(EventDiscipline, discipline_id)
+        if not discipline:
+            raise HTTPException(status_code=404, detail="Event discipline not found")
+        return discipline
+
+    async def _require_entry(self, entry_id: int) -> EventEntry:
+        entry = await self._session.get(EventEntry, entry_id)
+        if not entry:
+            raise HTTPException(status_code=404, detail="Event entry not found")
+        return entry
 
     async def create_event(self, payload: EventCreate) -> EventRead:
         event = Event(**payload.model_dump())
@@ -22,6 +72,243 @@ class EventsService:
         result = await self._session.execute(select(Event))
         events = result.scalars().all()
         return [EventRead.model_validate(event) for event in events]
+
+    async def get_event_detail(self, event_id: int) -> EventDetailRead:
+        result = await self._session.execute(
+            select(Event)
+                .where(Event.id == event_id)
+                .options(
+                    selectinload(Event.sessions),
+                    selectinload(Event.disciplines)
+                    .options(
+                        selectinload(EventDiscipline.session),
+                        selectinload(EventDiscipline.entries).selectinload(EventEntry.roster),
+                    ),
+                )
+        )
+        event = result.scalar_one_or_none()
+        if event is None:
+            raise HTTPException(status_code=404, detail="Event not found")
+        detail = EventDetailRead.model_validate(event)
+
+        latest_update: datetime | None = None
+        for discipline in event.disciplines:
+            for entry in discipline.entries:
+                if entry.updated_at is not None and (
+                    latest_update is None or entry.updated_at > latest_update
+                ):
+                    latest_update = entry.updated_at
+        detail.latest_update = latest_update
+        return detail
+
+    async def create_session(
+        self, event_id: int, payload: EventSessionCreate
+    ) -> EventSessionRead:
+        await self._require_event(event_id)
+        session = EventSession(event_id=event_id, **payload.model_dump())
+        self._session.add(session)
+        await self._session.commit()
+        await self._session.refresh(session)
+        return EventSessionRead.model_validate(session)
+
+    async def create_discipline(
+        self, event_id: int, payload: EventDisciplineCreate
+    ) -> EventDisciplineRead:
+        await self._require_event(event_id)
+        if payload.session_id is not None:
+            session = await self._require_session(payload.session_id)
+            if session.event_id != event_id:
+                raise HTTPException(status_code=400, detail="Session does not belong to event")
+        discipline = EventDiscipline(event_id=event_id, **payload.model_dump())
+        self._session.add(discipline)
+        await self._session.commit()
+        await self._session.refresh(discipline, attribute_names=["entries", "session"])
+        return EventDisciplineRead.model_validate(discipline)
+
+    async def create_entry(
+        self, discipline_id: int, payload: EventEntryCreate
+    ) -> EventEntryRead:
+        discipline = await self._require_discipline(discipline_id)
+        entry = EventEntry(discipline_id=discipline.id, **payload.model_dump())
+        self._session.add(entry)
+        await self._session.commit()
+        await self._session.refresh(entry, attribute_names=["roster", "updated_at"])
+        return EventEntryRead.model_validate(entry)
+
+    async def update_entry(self, entry_id: int, payload: EventEntryUpdate) -> EventEntryRead:
+        entry = await self._require_entry(entry_id)
+        data = payload.model_dump(exclude_unset=True)
+        if not data:
+            return EventEntryRead.model_validate(entry)
+        for key, value in data.items():
+            setattr(entry, key, value)
+        self._session.add(entry)
+        await self._session.commit()
+        await self._session.refresh(entry, attribute_names=["roster", "updated_at"])
+        return EventEntryRead.model_validate(entry)
+
+    async def generate_fake_timeline(
+        self, event_id: int, payload: EventFakeTimelineRequest
+    ) -> EventDetailRead:
+        await self._require_event(event_id)
+
+        # Clear existing structure for a clean demo slate.
+        await self._session.execute(
+            delete(EventEntry).where(
+                EventEntry.discipline_id.in_(
+                    select(EventDiscipline.id).where(EventDiscipline.event_id == event_id)
+                )
+            )
+        )
+        await self._session.execute(
+            delete(EventDiscipline).where(EventDiscipline.event_id == event_id)
+        )
+        await self._session.execute(delete(EventSession).where(EventSession.event_id == event_id))
+
+        base_start = payload.start_time or datetime.now(tz=timezone.utc)
+        session_templates = [
+            "Opening Session",
+            "Morning Heats",
+            "Afternoon Finals",
+            "Golden Night",
+            "Relay Showcase",
+            "Closing Ceremony",
+        ]
+        discipline_templates = [
+            ("100m", "Sprints"),
+            ("200m", "Sprints"),
+            ("400m", "Sprints"),
+            ("800m", "Middle Distance"),
+            ("1500m", "Middle Distance"),
+            ("5000m", "Distance"),
+            ("110m Hurdles", "Hurdles"),
+            ("400m Hurdles", "Hurdles"),
+            ("Long Jump", "Jumps"),
+            ("Triple Jump", "Jumps"),
+            ("High Jump", "Jumps"),
+            ("Pole Vault", "Jumps"),
+            ("Shot Put", "Throws"),
+            ("Discus Throw", "Throws"),
+            ("Javelin Throw", "Throws"),
+            ("4x100m Relay", "Relays"),
+            ("4x400m Relay", "Relays"),
+        ]
+        team_names = [
+            "Andean Flyers",
+            "Caribbean Storm",
+            "Patagonia Peaks",
+            "Amazon Striders",
+            "Pacífico Runners",
+            "Altiplano Club",
+            "Granada Hurdlers",
+            "Cusco Distance",
+            "Quito Relays",
+            "Buenos Aires Elite",
+            "Montevideo Vault",
+            "Santiago Throws",
+        ]
+        athlete_names = [
+            "Valentina Ríos",
+            "Mateo Herrera",
+            "Camila Ibáñez",
+            "Thiago López",
+            "Luisa Carvalho",
+            "Daniel Torres",
+            "Renata Gómez",
+            "Pablo Medina",
+            "Sofía Vargas",
+            "Gabriel da Costa",
+            "Mariana Núñez",
+            "Felipe Cruz",
+        ]
+
+        sessions: list[EventSession] = []
+        for index in range(payload.sessions):
+            session = EventSession(
+                event_id=event_id,
+                name=session_templates[index % len(session_templates)],
+                start_time=base_start + timedelta(hours=index * 3),
+                end_time=base_start + timedelta(hours=(index * 3) + 2),
+                venue="Main Stadium",
+                status=EventSessionStatus.LIVE
+                if index == 0
+                else EventSessionStatus.SCHEDULED,
+                description="Automatically generated for demo purposes.",
+            )
+            self._session.add(session)
+            sessions.append(session)
+
+        await self._session.flush()
+
+        lane_range = list(range(1, payload.lanes + 1))
+        generated_disciplines: list[EventDiscipline] = []
+
+        for session_index, session in enumerate(sessions):
+            for slot in range(payload.disciplines_per_session):
+                template_index = (session_index * payload.disciplines_per_session + slot) % len(
+                    discipline_templates
+                )
+                name, category = discipline_templates[template_index]
+                scheduled_start = (session.start_time or base_start) + timedelta(minutes=slot * 45)
+                scheduled_end = scheduled_start + timedelta(minutes=35)
+                status = (
+                    EventDisciplineStatus.FINALIZED
+                    if payload.include_results and session_index == 0 and slot == 0
+                    else EventDisciplineStatus.LIVE
+                    if session_index == 0 and slot == 1
+                    else EventDisciplineStatus.SCHEDULED
+                )
+                discipline = EventDiscipline(
+                    event_id=event_id,
+                    session_id=session.id,
+                    name=name,
+                    category=category,
+                    round_name="Final" if slot % 2 == 0 else "Semi-final",
+                    scheduled_start=scheduled_start,
+                    scheduled_end=scheduled_end,
+                    status=status,
+                    venue="Main Stadium",
+                    order=slot + 1,
+                )
+                self._session.add(discipline)
+                generated_disciplines.append(discipline)
+
+        await self._session.flush()
+
+        for discipline_index, discipline in enumerate(generated_disciplines):
+            entries_to_use = sample(athlete_names, k=min(len(athlete_names), payload.lanes))
+            teams_cycle = sample(team_names, k=min(len(team_names), payload.lanes))
+            for lane_number, (athlete, team) in enumerate(zip(entries_to_use, teams_cycle), start=1):
+                entry_status = (
+                    EventEntryStatus.FINISHED
+                    if payload.include_results and discipline_index == 0
+                    else EventEntryStatus.LIVE
+                    if discipline.status == EventDisciplineStatus.LIVE
+                    else EventEntryStatus.SCHEDULED
+                )
+                position = lane_number if entry_status == EventEntryStatus.FINISHED else None
+                result = None
+                points = None
+                if entry_status == EventEntryStatus.FINISHED:
+                    result = f"{10.2 + (lane_number * 0.07):.2f}s"
+                    points = max(0, (payload.lanes - lane_number + 1) * 2)
+                entry = EventEntry(
+                    discipline_id=discipline.id,
+                    athlete_name=athlete,
+                    team_name=team,
+                    lane=str(lane_range[lane_number - 1]),
+                    bib=f"{discipline_index + 1:02d}{lane_number:02d}",
+                    status=entry_status,
+                    position=position,
+                    result=result,
+                    points=points,
+                    notes="Demo entry",
+                )
+                self._session.add(entry)
+
+        await self._session.commit()
+
+        return await self.get_event_detail(event_id)
 
 
 async def get_events_service(session: AsyncSession = Depends(get_session)) -> EventsService:

--- a/src/app/web/static/app.js
+++ b/src/app/web/static/app.js
@@ -113,6 +113,49 @@ const translations = {
     "home.events_submit": "Create event",
     "home.events_empty": "No events have been scheduled yet.",
     "home.events_hint": "Use the meet form or reload the curated calendar of sample events.",
+    "event_detail.eyebrow": "Live meet operations",
+    "event_detail.refresh": "Refresh",
+    "event_detail.generate_demo": "Generate demo timeline",
+    "event_detail.overview_title": "Event overview",
+    "event_detail.overview_subtitle": "Track status, federation ownership, and last update.",
+    "event_detail.summary_location": "Location",
+    "event_detail.summary_dates": "Dates",
+    "event_detail.summary_federation": "Federation",
+    "event_detail.summary_status": "Live status",
+    "event_detail.schedule_title": "Sessions & timetable",
+    "event_detail.schedule_subtitle": "Monitor blocks of competition and venues.",
+    "event_detail.schedule_empty": "No sessions have been scheduled yet.",
+    "event_detail.schedule_hint": "Create a session above or generate demo data to populate the timeline.",
+    "event_detail.disciplines_title": "Events & scoreboards",
+    "event_detail.disciplines_subtitle": "Heat sheets update instantly for track-side ops.",
+    "event_detail.disciplines_empty": "No disciplines are attached to this meet yet.",
+    "event_detail.disciplines_hint": "Generate demo data or use the API to seed events.",
+    "event_detail.last_update": "Updated",
+    "event_detail.status.scheduled": "Scheduled",
+    "event_detail.status.live": "Live",
+    "event_detail.status.completed": "Completed",
+    "event_detail.status.delayed": "Delayed",
+    "event_detail.status.finalized": "Finalized",
+    "event_detail.status.ready": "Ready",
+    "event_detail.status.finished": "Finished",
+    "event_detail.status.dns": "Did not start",
+    "event_detail.status.dq": "Disqualified",
+    "event_detail.table_position": "Pos",
+    "event_detail.table_lane": "Lane",
+    "event_detail.table_athlete": "Athlete",
+    "event_detail.table_team": "Team / Roster",
+    "event_detail.table_result": "Result",
+    "event_detail.table_points": "Points",
+    "event_detail.table_status": "Status",
+    "event_detail.meta.sessions": "{count} sessions scheduled",
+    "event_detail.meta.sessions_single": "1 session scheduled",
+    "event_detail.meta.live_sessions": "{count} session live",
+    "event_detail.meta.live_sessions_plural": "{count} sessions live",
+    "event_detail.generate_toast": "Demo timeline generated for this meet.",
+    "event_detail.demo_error": "Unable to generate the demo timeline.",
+    "event_detail.refresh_error": "Unable to load live event data.",
+    "event_detail.group_unscheduled": "Unassigned session",
+    "event_detail.scoreboard_empty": "No entries yet",
     "home.rosters_title": "Rosters",
     "home.rosters_subtitle": "Keep squads aligned with verified athlete eligibility.",
     "home.rosters_empty": "No rosters available yet.",
@@ -294,6 +337,49 @@ const translations = {
     "home.events_submit": "Crear evento",
     "home.events_empty": "Todavía no hay eventos programados.",
     "home.events_hint": "Usa el formulario o recarga el calendario curado de eventos.",
+    "event_detail.eyebrow": "Operaciones en vivo",
+    "event_detail.refresh": "Actualizar",
+    "event_detail.generate_demo": "Generar cronograma demo",
+    "event_detail.overview_title": "Resumen del evento",
+    "event_detail.overview_subtitle": "Controla estado, federación responsable y última actualización.",
+    "event_detail.summary_location": "Ubicación",
+    "event_detail.summary_dates": "Fechas",
+    "event_detail.summary_federation": "Federación",
+    "event_detail.summary_status": "Estado en vivo",
+    "event_detail.schedule_title": "Sesiones y horario",
+    "event_detail.schedule_subtitle": "Monitorea bloques de competencia y sedes.",
+    "event_detail.schedule_empty": "No hay sesiones programadas aún.",
+    "event_detail.schedule_hint": "Crea una sesión arriba o genera datos demo para poblar la agenda.",
+    "event_detail.disciplines_title": "Pruebas y tableros",
+    "event_detail.disciplines_subtitle": "Las hojas de prueba se actualizan al instante en pista.",
+    "event_detail.disciplines_empty": "No hay pruebas asociadas a este meeting todavía.",
+    "event_detail.disciplines_hint": "Genera datos demo o usa la API para cargar pruebas.",
+    "event_detail.last_update": "Actualizado",
+    "event_detail.status.scheduled": "Programado",
+    "event_detail.status.live": "En vivo",
+    "event_detail.status.completed": "Completado",
+    "event_detail.status.delayed": "Retrasado",
+    "event_detail.status.finalized": "Finalizado",
+    "event_detail.status.ready": "Listo",
+    "event_detail.status.finished": "Terminado",
+    "event_detail.status.dns": "No salió",
+    "event_detail.status.dq": "Descalificado",
+    "event_detail.table_position": "Pos",
+    "event_detail.table_lane": "Carril",
+    "event_detail.table_athlete": "Atleta",
+    "event_detail.table_team": "Equipo / Roster",
+    "event_detail.table_result": "Resultado",
+    "event_detail.table_points": "Puntos",
+    "event_detail.table_status": "Estado",
+    "event_detail.meta.sessions": "{count} sesiones programadas",
+    "event_detail.meta.sessions_single": "1 sesión programada",
+    "event_detail.meta.live_sessions": "{count} sesión en vivo",
+    "event_detail.meta.live_sessions_plural": "{count} sesiones en vivo",
+    "event_detail.generate_toast": "Cronograma demo generado para este meeting.",
+    "event_detail.demo_error": "No se pudo generar el cronograma demo.",
+    "event_detail.refresh_error": "No se pudo cargar la información en vivo del evento.",
+    "event_detail.group_unscheduled": "Sesión sin asignar",
+    "event_detail.scoreboard_empty": "Aún sin participantes",
     "home.rosters_title": "Planteles",
     "home.rosters_subtitle": "Mantén los equipos alineados con elegibilidad verificada.",
     "home.rosters_empty": "Aún no hay planteles disponibles.",
@@ -475,6 +561,49 @@ const translations = {
     "home.events_submit": "Criar evento",
     "home.events_empty": "Nenhum evento agendado ainda.",
     "home.events_hint": "Use o formulário ou recarregue o calendário curado.",
+    "event_detail.eyebrow": "Operações ao vivo",
+    "event_detail.refresh": "Atualizar",
+    "event_detail.generate_demo": "Gerar cronograma demo",
+    "event_detail.overview_title": "Visão geral do evento",
+    "event_detail.overview_subtitle": "Acompanhe status, federação responsável e última atualização.",
+    "event_detail.summary_location": "Local",
+    "event_detail.summary_dates": "Datas",
+    "event_detail.summary_federation": "Federação",
+    "event_detail.summary_status": "Status ao vivo",
+    "event_detail.schedule_title": "Sessões e agenda",
+    "event_detail.schedule_subtitle": "Monitore blocos de competição e locais.",
+    "event_detail.schedule_empty": "Nenhuma sessão agendada ainda.",
+    "event_detail.schedule_hint": "Crie uma sessão acima ou gere dados demo para preencher a agenda.",
+    "event_detail.disciplines_title": "Provas e placares",
+    "event_detail.disciplines_subtitle": "As heat sheets atualizam instantaneamente na pista.",
+    "event_detail.disciplines_empty": "Nenhuma prova vinculada a este meeting ainda.",
+    "event_detail.disciplines_hint": "Gere dados demo ou use a API para cadastrar provas.",
+    "event_detail.last_update": "Atualizado",
+    "event_detail.status.scheduled": "Programado",
+    "event_detail.status.live": "Ao vivo",
+    "event_detail.status.completed": "Concluído",
+    "event_detail.status.delayed": "Atrasado",
+    "event_detail.status.finalized": "Finalizado",
+    "event_detail.status.ready": "Pronto",
+    "event_detail.status.finished": "Finalizado",
+    "event_detail.status.dns": "Não largou",
+    "event_detail.status.dq": "Desclassificado",
+    "event_detail.table_position": "Pos",
+    "event_detail.table_lane": "Raia",
+    "event_detail.table_athlete": "Atleta",
+    "event_detail.table_team": "Equipe / Roster",
+    "event_detail.table_result": "Resultado",
+    "event_detail.table_points": "Pontos",
+    "event_detail.table_status": "Status",
+    "event_detail.meta.sessions": "{count} sessões agendadas",
+    "event_detail.meta.sessions_single": "1 sessão agendada",
+    "event_detail.meta.live_sessions": "{count} sessão ao vivo",
+    "event_detail.meta.live_sessions_plural": "{count} sessões ao vivo",
+    "event_detail.generate_toast": "Cronograma demo gerado para este meeting.",
+    "event_detail.demo_error": "Não foi possível gerar o cronograma demo.",
+    "event_detail.refresh_error": "Não foi possível carregar os dados ao vivo do evento.",
+    "event_detail.group_unscheduled": "Sessão sem atribuição",
+    "event_detail.scoreboard_empty": "Sem inscrições ainda",
     "home.rosters_title": "Elencos",
     "home.rosters_subtitle": "Mantenha as equipes alinhadas com elegibilidade verificada.",
     "home.rosters_empty": "Nenhum elenco disponível ainda.",
@@ -731,6 +860,7 @@ const sampleAthletes = [
 
 const sampleEvents = [
   {
+    id: 1,
     name: "Aurora Indoor Classic",
     location: "Oslo, Norway",
     start_date: "2024-02-10",
@@ -738,6 +868,7 @@ const sampleEvents = [
     federation_id: null,
   },
   {
+    id: 2,
     name: "Sunset Coast Invitational",
     location: "Porto, Portugal",
     start_date: "2024-04-22",
@@ -745,6 +876,7 @@ const sampleEvents = [
     federation_id: null,
   },
   {
+    id: 3,
     name: "Highlands Distance Festival",
     location: "Edinburgh, Scotland",
     start_date: "2024-09-14",
@@ -801,6 +933,196 @@ const sampleNews = [
   },
 ];
 
+function buildSampleEventDetail(eventId = 1) {
+  const now = new Date();
+  const start = new Date(now.getTime() - 3600000);
+  const end = new Date(now.getTime() + 2 * 86400000);
+  const sessionOneStart = new Date(now.getTime() - 1800000);
+  const sessionOneEnd = new Date(now.getTime() + 3600000);
+  const sessionTwoStart = new Date(now.getTime() + 7200000);
+  const sessionTwoEnd = new Date(now.getTime() + 10800000);
+  const sessions = [
+    {
+      id: 1,
+      event_id: eventId,
+      name: "Morning Session",
+      start_time: sessionOneStart.toISOString(),
+      end_time: sessionOneEnd.toISOString(),
+      venue: "Main Stadium",
+      status: "live",
+      description: "Sample data session",
+    },
+    {
+      id: 2,
+      event_id: eventId,
+      name: "Evening Finals",
+      start_time: sessionTwoStart.toISOString(),
+      end_time: sessionTwoEnd.toISOString(),
+      venue: "Main Stadium",
+      status: "scheduled",
+      description: "Sample finals block",
+    },
+  ];
+  const disciplines = [
+    {
+      id: 1,
+      event_id: eventId,
+      session_id: sessions[0].id,
+      name: "100m",
+      category: "Sprints",
+      round_name: "Final",
+      scheduled_start: sessionOneStart.toISOString(),
+      scheduled_end: new Date(sessionOneStart.getTime() + 1800000).toISOString(),
+      status: "finalized",
+      venue: "Main Stadium",
+      order: 1,
+      session: { ...sessions[0] },
+      entries: [
+        {
+          id: 1,
+          discipline_id: 1,
+          athlete_name: "Valentina Ríos",
+          team_name: "Andean Flyers",
+          status: "finished",
+          lane: "4",
+          position: 1,
+          result: "11.32s",
+          points: 12,
+          updated_at: now.toISOString(),
+        },
+        {
+          id: 2,
+          discipline_id: 1,
+          athlete_name: "Mateo Herrera",
+          team_name: "Caribbean Storm",
+          status: "finished",
+          lane: "5",
+          position: 2,
+          result: "11.40s",
+          points: 10,
+          updated_at: now.toISOString(),
+        },
+        {
+          id: 3,
+          discipline_id: 1,
+          athlete_name: "Camila Ibáñez",
+          team_name: "Patagonia Peaks",
+          status: "finished",
+          lane: "3",
+          position: 3,
+          result: "11.55s",
+          points: 8,
+          updated_at: now.toISOString(),
+        },
+        {
+          id: 4,
+          discipline_id: 1,
+          athlete_name: "Thiago López",
+          team_name: "Amazon Striders",
+          status: "finished",
+          lane: "2",
+          position: 4,
+          result: "11.60s",
+          points: 6,
+          updated_at: now.toISOString(),
+        },
+      ],
+    },
+    {
+      id: 2,
+      event_id: eventId,
+      session_id: sessions[0].id,
+      name: "Long Jump",
+      category: "Jumps",
+      round_name: "Final",
+      scheduled_start: new Date(sessionOneStart.getTime() + 2400000).toISOString(),
+      scheduled_end: new Date(sessionOneStart.getTime() + 5400000).toISOString(),
+      status: "live",
+      venue: "Jumps Apron",
+      order: 2,
+      session: { ...sessions[0] },
+      entries: [
+        {
+          id: 5,
+          discipline_id: 2,
+          athlete_name: "Renata Gómez",
+          team_name: "Cusco Distance",
+          status: "live",
+          lane: null,
+          position: null,
+          result: "6.48m",
+          points: null,
+          updated_at: now.toISOString(),
+        },
+        {
+          id: 6,
+          discipline_id: 2,
+          athlete_name: "Daniel Torres",
+          team_name: "Granada Hurdlers",
+          status: "live",
+          lane: null,
+          position: null,
+          result: "6.30m",
+          points: null,
+          updated_at: now.toISOString(),
+        },
+      ],
+    },
+    {
+      id: 3,
+      event_id: eventId,
+      session_id: sessions[1].id,
+      name: "4x400m Relay",
+      category: "Relays",
+      round_name: "Final",
+      scheduled_start: sessionTwoStart.toISOString(),
+      scheduled_end: new Date(sessionTwoStart.getTime() + 3600000).toISOString(),
+      status: "scheduled",
+      venue: "Main Stadium",
+      order: 1,
+      session: { ...sessions[1] },
+      entries: [
+        {
+          id: 7,
+          discipline_id: 3,
+          athlete_name: "Pacífico Runners",
+          team_name: "Pacífico Runners",
+          status: "scheduled",
+          lane: "4",
+          position: null,
+          result: null,
+          points: null,
+          updated_at: now.toISOString(),
+        },
+        {
+          id: 8,
+          discipline_id: 3,
+          athlete_name: "Quito Relays",
+          team_name: "Quito Relays",
+          status: "scheduled",
+          lane: "5",
+          position: null,
+          result: null,
+          points: null,
+          updated_at: now.toISOString(),
+        },
+      ],
+    },
+  ];
+
+  return {
+    id: eventId,
+    name: "Aurora Indoor Classic",
+    location: "Oslo, Norway",
+    start_date: start.toISOString(),
+    end_date: end.toISOString(),
+    federation_id: null,
+    sessions,
+    disciplines,
+    latest_update: now.toISOString(),
+  };
+}
+
 const state = {
   athletes: [],
   events: [],
@@ -811,6 +1133,67 @@ const state = {
   news: sampleNews.slice(),
   federationToken: null,
 };
+
+function formatDateTime(value) {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatTimeRange(start, end) {
+  const startDate = start ? new Date(start) : null;
+  const endDate = end ? new Date(end) : null;
+  if (startDate && Number.isNaN(startDate.getTime())) {
+    return "";
+  }
+  if (endDate && Number.isNaN(endDate.getTime())) {
+    return "";
+  }
+  if (startDate && endDate) {
+    const sameDay = startDate.toDateString() === endDate.toDateString();
+    const startText = startDate.toLocaleString(undefined, {
+      month: sameDay ? undefined : "short",
+      day: sameDay ? undefined : "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const endText = endDate.toLocaleString(undefined, {
+      month: sameDay ? undefined : "short",
+      day: sameDay ? undefined : "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    return `${startText} – ${endText}`;
+  }
+  if (startDate) {
+    return startDate.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  if (endDate) {
+    return endDate.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  return "";
+}
 
 function formatDate(value) {
   if (!value) {
@@ -900,8 +1283,9 @@ if (pageId === "home") {
       const start = event.start_date ? new Date(event.start_date) : null;
       const end = event.end_date ? new Date(event.end_date) : null;
       const dateRange = start && end ? `${formatDate(start)} – ${formatDate(end)}` : "Date TBA";
+      const eventLink = event.id ? `<a href="/events/${event.id}">${event.name}</a>` : event.name;
       item.innerHTML = `
-        <h3>${event.name}</h3>
+        <h3>${eventLink}</h3>
         <div class="card-meta">
           <span class="tag">${event.location}</span>
           <span>${dateRange}</span>
@@ -1005,11 +1389,13 @@ if (pageId === "home") {
       events.forEach((event) => {
         const start = event.start_date ? new Date(event.start_date) : null;
         const end = event.end_date ? new Date(event.end_date) : null;
+        const eventId = event.id ?? null;
         results.push({
           category: "Events",
           title: event.name,
           subtitle: event.location,
           detail: start && end ? `${formatDate(start)} – ${formatDate(end)}` : "Dates TBA",
+          url: eventId ? `/events/${eventId}` : undefined,
         });
       });
     }
@@ -1123,6 +1509,7 @@ if (pageId === "home") {
       renderSearchResults();
     } catch (error) {
       const fallback = sampleEvents.map((event, index) => ({
+        id: event.id ?? index + 1,
         ...event,
         start_date: event.start_date || new Date(Date.now() + index * 604800000).toISOString(),
         end_date: event.end_date || new Date(Date.now() + (index * 604800000) + 86400000).toISOString(),
@@ -1390,13 +1777,14 @@ if (pageId === "events") {
       const end = event.end_date ? formatDate(event.end_date) : "";
       const item = document.createElement("li");
       item.className = "card";
+      const titleMarkup = event.id ? `<a href="/events/${event.id}">${event.name}</a>` : event.name;
       item.innerHTML = `
         <div class="card-meta">
           <span class="tag">${event.location || "TBA"}</span>
           ${start ? `<span>${start}${end ? ` – ${end}` : ""}</span>` : ""}
           ${event.federation_id ? `<span>Federation #${event.federation_id}</span>` : ""}
         </div>
-        <h3>${event.name}</h3>
+        <h3>${titleMarkup}</h3>
       `;
       list.appendChild(item);
     });
@@ -1408,6 +1796,7 @@ if (pageId === "events") {
       renderEventsPage();
     } catch (error) {
       events = sampleEvents.map((event, index) => ({
+        id: event.id ?? index + 1,
         ...event,
         start_date: event.start_date || new Date(Date.now() + index * 604800000).toISOString(),
         end_date: event.end_date || new Date(Date.now() + (index * 604800000) + 86400000).toISOString(),
@@ -1433,6 +1822,407 @@ if (pageId === "events") {
   }
 
   loadEventsPage();
+}
+if (pageId === "event-detail") {
+  const root = document.querySelector("#event-detail");
+  const nameElement = document.querySelector("#event-detail-name");
+  const metaElement = document.querySelector("#event-detail-meta");
+  const summaryLocation = document.querySelector("#event-summary-location");
+  const summaryDates = document.querySelector("#event-summary-dates");
+  const summaryFederation = document.querySelector("#event-summary-federation");
+  const summaryStatus = document.querySelector("#event-summary-status");
+  const sessionsList = document.querySelector("#event-session-list");
+  const sessionsEmpty = document.querySelector("#event-sessions-empty");
+  const disciplinesContainer = document.querySelector("#event-discipline-container");
+  const disciplinesEmpty = document.querySelector("#event-disciplines-empty");
+  const latestUpdateLabel = document.querySelector("#event-latest-update");
+  const refreshButton = document.querySelector("#event-refresh");
+  const demoButton = document.querySelector("#event-generate-demo");
+
+  if (!root) {
+    return;
+  }
+
+  const rawEventId = Number.parseInt(root.dataset.eventId || "", 10);
+  const eventId = Number.isNaN(rawEventId) ? null : rawEventId;
+  let detail = null;
+
+  function t(key) {
+    const dictionary = translations[document.documentElement.lang] || translations.en;
+    return dictionary[key] || translations.en[key] || key;
+  }
+
+  function statusLabel(status) {
+    if (!status) {
+      return "";
+    }
+    const normalized = String(status).toLowerCase();
+    const key = `event_detail.status.${normalized}`;
+    const label = t(key);
+    return label === key ? String(status) : label;
+  }
+
+  function createStatusChip(status) {
+    if (!status) {
+      return "";
+    }
+    const label = statusLabel(status);
+    const normalized = String(status).toLowerCase();
+    return `<span class="status-chip status-${normalized}">${label}</span>`;
+  }
+
+  function renderHeader() {
+    if (!detail) {
+      return;
+    }
+    if (nameElement) {
+      nameElement.textContent = detail.name || "—";
+    }
+    if (metaElement) {
+      const parts = [];
+      if (detail.location) {
+        parts.push(detail.location);
+      }
+      if (detail.start_date && detail.end_date) {
+        parts.push(`${formatDate(detail.start_date)} – ${formatDate(detail.end_date)}`);
+      } else if (detail.start_date) {
+        parts.push(formatDate(detail.start_date));
+      }
+      const liveCount = Array.isArray(detail.sessions)
+        ? detail.sessions.filter((session) => session.status === "live").length
+        : 0;
+      const totalSessions = detail.sessions?.length ?? 0;
+      if (liveCount > 0) {
+        parts.push(
+          liveCount === 1
+            ? t("event_detail.meta.live_sessions").replace("{count}", String(liveCount))
+            : t("event_detail.meta.live_sessions_plural").replace("{count}", String(liveCount))
+        );
+      } else if (totalSessions > 0) {
+        parts.push(
+          totalSessions === 1
+            ? t("event_detail.meta.sessions_single")
+            : t("event_detail.meta.sessions").replace("{count}", String(totalSessions))
+        );
+      }
+      metaElement.textContent = parts.join(" · ") || "";
+    }
+  }
+
+  function renderSummary() {
+    if (!detail) {
+      return;
+    }
+    if (summaryLocation) {
+      summaryLocation.textContent = detail.location || "—";
+    }
+    if (summaryDates) {
+      if (detail.start_date && detail.end_date) {
+        summaryDates.textContent = `${formatDate(detail.start_date)} – ${formatDate(detail.end_date)}`;
+      } else if (detail.start_date) {
+        summaryDates.textContent = formatDate(detail.start_date);
+      } else {
+        summaryDates.textContent = "—";
+      }
+    }
+    if (summaryFederation) {
+      summaryFederation.textContent = detail.federation_id
+        ? `#${detail.federation_id}`
+        : "—";
+    }
+    if (summaryStatus) {
+      const sessionStatuses = Array.isArray(detail.sessions)
+        ? detail.sessions.map((session) => session.status)
+        : [];
+      const disciplineStatuses = Array.isArray(detail.disciplines)
+        ? detail.disciplines.map((discipline) => discipline.status)
+        : [];
+      let summaryKey = "scheduled";
+      if (disciplineStatuses.includes("live") || sessionStatuses.includes("live")) {
+        summaryKey = "live";
+      } else if (disciplineStatuses.includes("finalized") || sessionStatuses.includes("completed")) {
+        summaryKey = "finalized";
+      } else if (sessionStatuses.includes("completed")) {
+        summaryKey = "completed";
+      }
+      summaryStatus.innerHTML = createStatusChip(summaryKey);
+    }
+    if (latestUpdateLabel) {
+      if (detail.latest_update) {
+        latestUpdateLabel.textContent = `${t("event_detail.last_update")}: ${formatDateTime(detail.latest_update)}`;
+      } else {
+        latestUpdateLabel.textContent = t("event_detail.last_update");
+      }
+    }
+  }
+
+  function renderSessions() {
+    if (!sessionsList || !sessionsEmpty) {
+      return;
+    }
+    sessionsList.innerHTML = "";
+    const sessions = Array.isArray(detail?.sessions) ? detail.sessions.slice() : [];
+    if (!sessions.length) {
+      sessionsEmpty.hidden = false;
+      return;
+    }
+    sessionsEmpty.hidden = true;
+    sessions
+      .sort((a, b) => {
+        const aTime = a.start_time ? new Date(a.start_time).getTime() : 0;
+        const bTime = b.start_time ? new Date(b.start_time).getTime() : 0;
+        return aTime - bTime;
+      })
+      .forEach((session) => {
+        const item = document.createElement("li");
+        item.className = "session-item";
+        const metaParts = [];
+        const timeRange = formatTimeRange(session.start_time, session.end_time);
+        if (timeRange) {
+          metaParts.push(timeRange);
+        }
+        if (session.venue) {
+          metaParts.push(session.venue);
+        }
+        if (session.description) {
+          metaParts.push(session.description);
+        }
+        item.innerHTML = `
+          <div class="session-item-header">
+            <h3>${session.name}</h3>
+            ${createStatusChip(session.status)}
+          </div>
+          <p class="session-item-meta">${metaParts.join(" · ")}</p>
+        `;
+        sessionsList.appendChild(item);
+      });
+  }
+
+  function renderDisciplines() {
+    if (!disciplinesContainer || !disciplinesEmpty) {
+      return;
+    }
+    disciplinesContainer.innerHTML = "";
+    const disciplines = Array.isArray(detail?.disciplines) ? detail.disciplines.slice() : [];
+    if (!disciplines.length) {
+      disciplinesEmpty.hidden = false;
+      return;
+    }
+    disciplinesEmpty.hidden = true;
+
+    const groups = new Map();
+    disciplines.forEach((discipline) => {
+      const key = discipline.session_id ?? "unscheduled";
+      if (!groups.has(key)) {
+        groups.set(key, {
+          session: discipline.session ?? null,
+          disciplines: [],
+        });
+      }
+      groups.get(key).disciplines.push(discipline);
+    });
+
+    const sortedGroups = Array.from(groups.values()).sort((a, b) => {
+      const aTime = a.session?.start_time ? new Date(a.session.start_time).getTime() : 0;
+      const bTime = b.session?.start_time ? new Date(b.session.start_time).getTime() : 0;
+      return aTime - bTime;
+    });
+
+    sortedGroups.forEach((group) => {
+      const section = document.createElement("section");
+      section.className = "discipline-group";
+      const header = document.createElement("header");
+      header.className = "discipline-group-header";
+      const title = document.createElement("h3");
+      title.textContent = group.session?.name || t("event_detail.group_unscheduled");
+      header.appendChild(title);
+      if (group.session?.start_time || group.session?.end_time) {
+        const time = document.createElement("p");
+        time.className = "discipline-group-meta";
+        time.textContent = formatTimeRange(group.session?.start_time, group.session?.end_time);
+        header.appendChild(time);
+      }
+      section.appendChild(header);
+
+      const list = document.createElement("div");
+      list.className = "discipline-list";
+
+      group.disciplines
+        .slice()
+        .sort((a, b) => {
+          const aOrder = a.order ?? 0;
+          const bOrder = b.order ?? 0;
+          return aOrder - bOrder;
+        })
+        .forEach((discipline) => {
+          const card = document.createElement("article");
+          card.className = "discipline-card";
+          const metaParts = [];
+          const disciplineTime = formatTimeRange(discipline.scheduled_start, discipline.scheduled_end);
+          if (disciplineTime) {
+            metaParts.push(disciplineTime);
+          }
+          if (discipline.venue) {
+            metaParts.push(discipline.venue);
+          }
+          card.innerHTML = `
+            <div class="discipline-card-header">
+              <div>
+                <h4>${discipline.name}${discipline.round_name ? ` · ${discipline.round_name}` : ""}</h4>
+                <p class="discipline-meta">${metaParts.join(" · ")}</p>
+              </div>
+              ${createStatusChip(discipline.status)}
+            </div>
+          `;
+
+          const scoreboardWrapper = document.createElement("div");
+          scoreboardWrapper.className = "discipline-scoreboard";
+
+          const entries = Array.isArray(discipline.entries) ? discipline.entries.slice() : [];
+          if (!entries.length) {
+            const empty = document.createElement("p");
+            empty.className = "scoreboard-empty";
+            empty.textContent = t("event_detail.scoreboard_empty");
+            scoreboardWrapper.appendChild(empty);
+          } else {
+            const table = document.createElement("table");
+            table.className = "scoreboard";
+            table.innerHTML = `
+              <thead>
+                <tr>
+                  <th scope="col">${t("event_detail.table_position")}</th>
+                  <th scope="col">${t("event_detail.table_lane")}</th>
+                  <th scope="col">${t("event_detail.table_athlete")}</th>
+                  <th scope="col">${t("event_detail.table_team")}</th>
+                  <th scope="col">${t("event_detail.table_result")}</th>
+                  <th scope="col">${t("event_detail.table_points")}</th>
+                  <th scope="col">${t("event_detail.table_status")}</th>
+                </tr>
+              </thead>
+            `;
+            const tbody = document.createElement("tbody");
+            entries
+              .sort((a, b) => {
+                const aPos = a.position ?? null;
+                const bPos = b.position ?? null;
+                if (aPos && bPos) {
+                  return aPos - bPos;
+                }
+                if (aPos && !bPos) {
+                  return -1;
+                }
+                if (!aPos && bPos) {
+                  return 1;
+                }
+                const aLane = a.lane ? Number.parseInt(a.lane, 10) : null;
+                const bLane = b.lane ? Number.parseInt(b.lane, 10) : null;
+                if (!Number.isNaN(aLane) && !Number.isNaN(bLane) && aLane !== null && bLane !== null) {
+                  return aLane - bLane;
+                }
+                return (a.athlete_name || "").localeCompare(b.athlete_name || "");
+              })
+              .forEach((entry) => {
+                const row = document.createElement("tr");
+                if (entry.position && entry.position <= 3) {
+                  row.classList.add(`scoreboard-medal-${entry.position}`);
+                }
+                const teamName = entry.team_name || entry.roster?.name || "—";
+                row.innerHTML = `
+                  <td>${entry.position ?? ""}</td>
+                  <td>${entry.lane ?? ""}</td>
+                  <td>${entry.athlete_name}</td>
+                  <td>${teamName}</td>
+                  <td>${entry.result ?? "—"}</td>
+                  <td>${entry.points ?? "—"}</td>
+                  <td>${statusLabel(entry.status)}</td>
+                `;
+                if (entry.notes) {
+                  const notesRow = document.createElement("tr");
+                  notesRow.className = "scoreboard-notes";
+                  notesRow.innerHTML = `
+                    <td colspan="7">${entry.notes}</td>
+                  `;
+                  tbody.appendChild(row);
+                  tbody.appendChild(notesRow);
+                } else {
+                  tbody.appendChild(row);
+                }
+              });
+            table.appendChild(tbody);
+            scoreboardWrapper.appendChild(table);
+          }
+
+          card.appendChild(scoreboardWrapper);
+          list.appendChild(card);
+        });
+
+      section.appendChild(list);
+      disciplinesContainer.appendChild(section);
+    });
+  }
+
+  function renderAll() {
+    if (!detail) {
+      return;
+    }
+    renderHeader();
+    renderSummary();
+    renderSessions();
+    renderDisciplines();
+  }
+
+  async function loadEventDetail() {
+    if (!eventId) {
+      detail = buildSampleEventDetail();
+      renderAll();
+      return;
+    }
+    try {
+      detail = await request(`/events/${eventId}`);
+      renderAll();
+    } catch (error) {
+      detail = buildSampleEventDetail(eventId);
+      renderAll();
+      notify("error", `${t("event_detail.refresh_error") || ""} (${error.message}). Showing demo data.`);
+      console.error(error);
+    }
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener("click", () => {
+      loadEventDetail();
+    });
+  }
+
+  if (demoButton) {
+    demoButton.addEventListener("click", async () => {
+      if (!eventId) {
+        detail = buildSampleEventDetail();
+        renderAll();
+        notify("success", t("event_detail.generate_toast"));
+        return;
+      }
+      try {
+        demoButton.disabled = true;
+        await request(`/events/${eventId}/demo`, {
+          method: "POST",
+          body: JSON.stringify({
+            start_time: new Date().toISOString(),
+            include_results: true,
+          }),
+        });
+        notify("success", t("event_detail.generate_toast"));
+        await loadEventDetail();
+      } catch (error) {
+        notify("error", `${t("event_detail.demo_error") || ""} (${error.message}).`);
+        console.error(error);
+      } finally {
+        demoButton.disabled = false;
+      }
+    });
+  }
+
+  loadEventDetail();
 }
 if (pageId === "rosters") {
   const list = document.querySelector("#rosters-page-list");

--- a/src/app/web/static/styles.css
+++ b/src/app/web/static/styles.css
@@ -492,6 +492,212 @@ select:focus {
   font-size: 0.9rem;
 }
 
+.event-summary {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.event-summary div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.event-summary dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.event-summary dd {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.15rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  background: rgba(148, 163, 184, 0.25);
+  color: var(--text);
+}
+
+.status-chip.status-live {
+  background: rgba(34, 197, 94, 0.2);
+  color: #bbf7d0;
+}
+
+.status-chip.status-finalized,
+.status-chip.status-completed {
+  background: rgba(59, 130, 246, 0.2);
+  color: #cbd5f5;
+}
+
+.status-chip.status-delayed,
+.status-chip.status-dq {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}
+
+.session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.session-item {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.session-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.session-item-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.session-item-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.discipline-groups {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.discipline-group {
+  display: grid;
+  gap: 1rem;
+}
+
+.discipline-group-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.discipline-group-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.discipline-group-meta {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.discipline-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.discipline-card {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.discipline-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.discipline-card-header h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.discipline-meta {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.discipline-scoreboard {
+  overflow-x: auto;
+}
+
+.scoreboard {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.scoreboard th,
+.scoreboard td {
+  text-align: left;
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.scoreboard thead th {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.scoreboard tbody tr {
+  font-size: 0.92rem;
+}
+
+.scoreboard tbody tr:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.scoreboard-medal-1 {
+  background: rgba(234, 179, 8, 0.12);
+}
+
+.scoreboard-medal-2 {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.scoreboard-medal-3 {
+  background: rgba(249, 115, 22, 0.12);
+}
+
+.scoreboard-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.scoreboard-notes td {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-style: italic;
+  padding-top: 0;
+}
+
 .tag {
   background: var(--highlight);
   color: var(--accent);

--- a/src/app/web/templates/event_detail.html
+++ b/src/app/web/templates/event_detail.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block title %}Event Detail – Trackeo{% endblock %}
+
+{% block content %}
+  <section class="page-hero" id="event-detail" data-event-id="{{ event_id }}">
+    <div>
+      <p class="eyebrow" data-l10n-key="event_detail.eyebrow">Live meet operations</p>
+      <h1 id="event-detail-name">—</h1>
+      <p id="event-detail-meta" class="hero-subtitle">—</p>
+    </div>
+    <div class="page-actions">
+      <button class="ghost" type="button" id="event-refresh" data-l10n-key="event_detail.refresh">Refresh</button>
+      <button class="primary" type="button" id="event-generate-demo" data-l10n-key="event_detail.generate_demo">Generate demo timeline</button>
+    </div>
+  </section>
+
+  <section class="panel" aria-labelledby="event-overview-title">
+    <div class="panel-header">
+      <div>
+        <h2 id="event-overview-title" data-l10n-key="event_detail.overview_title">Event overview</h2>
+        <p class="panel-subtitle" data-l10n-key="event_detail.overview_subtitle">Track status, federation ownership, and last update.</p>
+      </div>
+      <div class="panel-controls">
+        <span class="tag" id="event-latest-update" aria-live="polite">—</span>
+      </div>
+    </div>
+    <dl class="event-summary" id="event-summary">
+      <div>
+        <dt data-l10n-key="event_detail.summary_location">Location</dt>
+        <dd id="event-summary-location">—</dd>
+      </div>
+      <div>
+        <dt data-l10n-key="event_detail.summary_dates">Dates</dt>
+        <dd id="event-summary-dates">—</dd>
+      </div>
+      <div>
+        <dt data-l10n-key="event_detail.summary_federation">Federation</dt>
+        <dd id="event-summary-federation">—</dd>
+      </div>
+      <div>
+        <dt data-l10n-key="event_detail.summary_status">Live status</dt>
+        <dd id="event-summary-status">—</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="panel" aria-labelledby="event-schedule-title">
+    <div class="panel-header">
+      <div>
+        <h2 id="event-schedule-title" data-l10n-key="event_detail.schedule_title">Sessions &amp; timetable</h2>
+        <p class="panel-subtitle" data-l10n-key="event_detail.schedule_subtitle">Monitor blocks of competition and venues.</p>
+      </div>
+    </div>
+    <div id="event-sessions-empty" class="empty-state" hidden>
+      <p data-l10n-key="event_detail.schedule_empty">No sessions have been scheduled yet.</p>
+      <p class="hint" data-l10n-key="event_detail.schedule_hint">Create a session above or generate demo data to populate the timeline.</p>
+    </div>
+    <ul class="session-list" id="event-session-list"></ul>
+  </section>
+
+  <section class="panel" aria-labelledby="event-disciplines-title">
+    <div class="panel-header">
+      <div>
+        <h2 id="event-disciplines-title" data-l10n-key="event_detail.disciplines_title">Events &amp; scoreboards</h2>
+        <p class="panel-subtitle" data-l10n-key="event_detail.disciplines_subtitle">Heat sheets update instantly for track-side ops.</p>
+      </div>
+    </div>
+    <div id="event-disciplines-empty" class="empty-state" hidden>
+      <p data-l10n-key="event_detail.disciplines_empty">No disciplines are attached to this meet yet.</p>
+      <p class="hint" data-l10n-key="event_detail.disciplines_hint">Generate demo data or use the API to seed events.</p>
+    </div>
+    <div id="event-discipline-container" class="discipline-groups" aria-live="polite"></div>
+  </section>
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -94,6 +94,18 @@ def create_app() -> FastAPI:
             fallback_markup="<h1>Events</h1>",
         )
 
+    @application.get("/events/{event_id}", response_class=HTMLResponse)
+    async def render_event_detail(
+        request: Request, event_id: int
+    ) -> HTMLResponse:
+        return _template_response(
+            request,
+            "event_detail.html",
+            page_id="event-detail",
+            fallback_markup=f"<h1>Event #{event_id}</h1>",
+            context={"event_id": event_id},
+        )
+
     @application.get("/rosters", response_class=HTMLResponse)
     async def render_rosters_page(request: Request) -> HTMLResponse:
         return _template_response(

--- a/tests/test_events_detail.py
+++ b/tests/test_events_detail.py
@@ -1,0 +1,88 @@
+import pytest
+from uuid import uuid4
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+async def test_event_detail_generation_flow(client):
+    unique = uuid4().hex[:6]
+    event_payload = {
+        "name": f"Continental Cup {unique}",
+        "location": "Atlanta, USA",
+        "start_date": "2025-03-01",
+        "end_date": "2025-03-03",
+        "federation_id": None,
+    }
+
+    create_response = await client.post("/api/v1/events/", json=event_payload)
+    assert create_response.status_code == 201
+    event = create_response.json()
+    event_id = event["id"]
+
+    demo_response = await client.post(
+        f"/api/v1/events/{event_id}/demo",
+        json={
+            "start_time": "2025-03-01T14:00:00Z",
+            "sessions": 2,
+            "disciplines_per_session": 2,
+            "lanes": 4,
+            "include_results": True,
+        },
+    )
+    assert demo_response.status_code == 200
+    detail = demo_response.json()
+    assert len(detail["sessions"]) == 2
+    assert detail["disciplines"]
+
+    first_entry = detail["disciplines"][0]["entries"][0]
+    update_response = await client.patch(
+        f"/api/v1/events/entries/{first_entry['id']}",
+        json={
+            "result": "10.05s",
+            "status": "finished",
+            "points": 14,
+            "position": 1,
+        },
+    )
+    assert update_response.status_code == 200
+    updated_entry = update_response.json()
+    assert updated_entry["result"] == "10.05s"
+    assert updated_entry["status"] == "finished"
+
+    session_response = await client.post(
+        f"/api/v1/events/{event_id}/sessions",
+        json={
+            "name": "Relay Finals",
+            "status": "scheduled",
+        },
+    )
+    assert session_response.status_code == 201
+    session_id = session_response.json()["id"]
+
+    discipline_response = await client.post(
+        f"/api/v1/events/{event_id}/disciplines",
+        json={
+            "name": "4x400m Relay",
+            "session_id": session_id,
+            "status": "scheduled",
+        },
+    )
+    assert discipline_response.status_code == 201
+    discipline_id = discipline_response.json()["id"]
+
+    entry_response = await client.post(
+        f"/api/v1/events/disciplines/{discipline_id}/entries",
+        json={
+            "athlete_name": "Demo Team",
+            "team_name": "Demo Team",
+            "status": "scheduled",
+        },
+    )
+    assert entry_response.status_code == 201
+
+    final_detail_response = await client.get(f"/api/v1/events/{event_id}")
+    assert final_detail_response.status_code == 200
+    final_detail = final_detail_response.json()
+    assert any(session["id"] == session_id for session in final_detail["sessions"])
+    assert any(discipline["id"] == discipline_id for discipline in final_detail["disciplines"])
+    assert final_detail["latest_update"] is not None


### PR DESCRIPTION
## Summary
- extend the event domain with sessions, disciplines, and entries so meets can track schedules, participants, and results
- expose API endpoints to fetch event detail, manage sessions/entries, and generate demo timelines for live testing
- build an event detail page with localized strings, schedule and scoreboard rendering, and supporting styles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0c036b5cc8325ae8dc48cbcf450d5