### PR TITLE
Render initial home lists before async refresh

### DIFF
--- a/src/app/web/static/app.js
+++ b/src/app/web/static/app.js
@@ -1270,6 +1270,9 @@ if (pageId === "home") {
     if (Array.isArray(initialHomeData.news) && initialHomeData.news.length) {
       state.news = initialHomeData.news;
     }
+    renderAthletes();
+    renderEvents();
+    renderSearchResults();
   }
 
   function renderAthletes() {
@@ -1558,6 +1561,8 @@ if (pageId === "home") {
   }
 
   function renderStaticSections() {
+    renderAthletes();
+    renderEvents();
     renderRosters();
     renderNews();
     renderSearchResults();


### PR DESCRIPTION
## Summary
- render home athletes and events immediately after hydrating state from server-provided data
- update the static render helper to include athlete and event sections so they stay in sync with the hydrated state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0f79e15ac832585479f5f7f9733d2